### PR TITLE
Add Comment APIs

### DIFF
--- a/task-service/src/main/java/com/taskmanagement/task/TaskServiceApplication.java
+++ b/task-service/src/main/java/com/taskmanagement/task/TaskServiceApplication.java
@@ -6,8 +6,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class TaskServiceApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(TaskServiceApplication.class, args);
-	}
+  public static void main(String[] args) {
+    SpringApplication.run(TaskServiceApplication.class, args);
+  }
 
 }

--- a/task-service/src/main/java/com/taskmanagement/task/api/CommentController.java
+++ b/task-service/src/main/java/com/taskmanagement/task/api/CommentController.java
@@ -1,0 +1,49 @@
+package com.taskmanagement.task.api;
+
+import com.taskmanagement.task.dto.CommentRequest;
+import com.taskmanagement.task.dto.CommentResponse;
+import com.taskmanagement.task.service.CommentService;
+import com.taskmanagement.task.service.model.Comment;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/tasks/{taskId}/comments")
+public class CommentController {
+
+  private final CommentService commentService;
+
+  @PreAuthorize("isAuthenticated()")
+  @PostMapping
+  public ResponseEntity<CommentResponse> addComment(@PathVariable String taskId,
+                                                    @RequestBody CommentRequest request) {
+    Comment comment = commentService.addComment(taskId, request.userId(), request.content());
+
+    return ResponseEntity.ok(new CommentResponse(comment));
+  }
+
+  @PreAuthorize("isAuthenticated()")
+  @GetMapping
+  public ResponseEntity<List<CommentResponse>> getComments(@PathVariable String taskId) {
+    List<Comment> comments = commentService.getCommentsByTaskId(taskId);
+    return ResponseEntity.ok(comments.stream().map(CommentResponse::new).toList());
+  }
+
+  @PreAuthorize("isAuthenticated()")
+  @DeleteMapping("/{commentId}")
+  public ResponseEntity<String> deleteComment(@PathVariable String commentId) {
+    commentService.deleteComment(commentId);
+    return ResponseEntity.ok("Comment deleted successfully");
+  }
+
+}

--- a/task-service/src/main/java/com/taskmanagement/task/dto/CommentRequest.java
+++ b/task-service/src/main/java/com/taskmanagement/task/dto/CommentRequest.java
@@ -1,0 +1,4 @@
+package com.taskmanagement.task.dto;
+
+public record CommentRequest(String userId, String content) {
+}

--- a/task-service/src/main/java/com/taskmanagement/task/dto/CommentResponse.java
+++ b/task-service/src/main/java/com/taskmanagement/task/dto/CommentResponse.java
@@ -1,0 +1,9 @@
+package com.taskmanagement.task.dto;
+
+import com.taskmanagement.task.service.model.Comment;
+
+public record CommentResponse(String id, String taskId, String userId, String content) {
+  public CommentResponse(Comment comment) {
+    this(comment.id(), comment.taskId(), comment.userId(), comment.content());
+  }
+}

--- a/task-service/src/main/java/com/taskmanagement/task/entity/CommentEntity.java
+++ b/task-service/src/main/java/com/taskmanagement/task/entity/CommentEntity.java
@@ -6,15 +6,20 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.MapsId;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Table
 @Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class CommentEntity {
 
   @Id

--- a/task-service/src/main/java/com/taskmanagement/task/repository/CommentRepository.java
+++ b/task-service/src/main/java/com/taskmanagement/task/repository/CommentRepository.java
@@ -1,10 +1,14 @@
 package com.taskmanagement.task.repository;
 
 import com.taskmanagement.task.entity.CommentEntity;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CommentRepository extends JpaRepository<CommentEntity, UUID> {
+
+  List<CommentEntity> findByTaskId(UUID taskId);
+
 }

--- a/task-service/src/main/java/com/taskmanagement/task/service/CommentService.java
+++ b/task-service/src/main/java/com/taskmanagement/task/service/CommentService.java
@@ -1,0 +1,51 @@
+package com.taskmanagement.task.service;
+
+import com.taskmanagement.task.entity.CommentEntity;
+import com.taskmanagement.task.entity.TaskEntity;
+import com.taskmanagement.task.repository.CommentRepository;
+import com.taskmanagement.task.repository.TaskRepository;
+import com.taskmanagement.task.service.model.Comment;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class CommentService {
+
+  private final CommentRepository commentRepository;
+  private final TaskRepository taskRepository;
+
+  @Transactional
+  public Comment addComment(String taskId, String userId, String content) {
+    TaskEntity task = taskRepository.findById(UUID.fromString(taskId))
+        .orElseThrow(() -> new EntityNotFoundException("Task not found"));
+
+    CommentEntity commentEntity = CommentEntity.builder()
+        .id(UUID.randomUUID())
+        .task(task)
+        .userId(UUID.fromString(userId))
+        .content(content)
+        .build();
+
+    CommentEntity savedComment = commentRepository.save(commentEntity);
+
+    return new Comment(savedComment.getId().toString(), taskId, userId, content);
+  }
+
+  public List<Comment> getCommentsByTaskId(String taskId) {
+    return commentRepository.findByTaskId(UUID.fromString(taskId)).stream()
+        .map(c -> new Comment(c.getId().toString(), taskId, c.getUserId().toString(),
+            c.getContent()))
+        .toList();
+  }
+
+  @Transactional
+  public void deleteComment(String commentId) {
+    commentRepository.deleteById(UUID.fromString(commentId));
+  }
+
+}

--- a/task-service/src/main/java/com/taskmanagement/task/service/model/Comment.java
+++ b/task-service/src/main/java/com/taskmanagement/task/service/model/Comment.java
@@ -1,0 +1,4 @@
+package com.taskmanagement.task.service.model;
+
+public record Comment(String id, String taskId, String userId, String content) {
+}


### PR DESCRIPTION
#### 🔥 **Summary**  
This PR introduces **CRUD functionality for comments** in `task-service`, allowing users to add, retrieve, and delete comments for tasks.  

#### ✅ **Changes in this PR**  
- **Added `CommentEntity`** with a relation to `TaskEntity`.  
- **Implemented REST API endpoints for managing comments:**  
  - `POST /tasks/{taskId}/comments` → Add a comment to a task  
  - `GET /tasks/{taskId}/comments` → Retrieve all comments for a task  
  - `DELETE /comments/{commentId}` → Remove a comment  
- **Created DTOs (`CommentRequest`, `CommentResponse`)** for API communication.  
- **Implemented `CommentService`** for business logic.  
- **Added `CommentRepository`** for database interactions.  

#### ⚡ **How to Test**  
1️⃣ **Run the service and test the following endpoints:**  
```http
POST /tasks/{taskId}/comments
{
  "userId": "550e8400-e29b-41d4-a716-446655440000",
  "content": "This is a test comment!"
}
```
```http
GET /tasks/{taskId}/comments
```
```http
DELETE /comments/{commentId}
```
2️⃣ **Verify that comments are correctly stored in PostgreSQL.**  
3️⃣ **Check if deleting a task removes its comments (`ON DELETE CASCADE`).**  